### PR TITLE
fixed bug in shapewidget (could not restore opacity to 1.0)

### DIFF
--- a/lib/advene/gui/edit/shapewidget.py
+++ b/lib/advene/gui/edit/shapewidget.py
@@ -185,7 +185,7 @@ class Shape(object):
         s=cls(name=element.attrib.get('name', cls.SHAPENAME))
         s.filled=( element.attrib.get('fill', 'none') != 'none' )
         s.color=element.attrib.get('stroke', None)
-        s.opacity = element.attrib.get('opacity', 1.0)
+        s.opacity = float(element.attrib.get('opacity', 1.0))
         style=element.attrib.get('style', '')
         m=stroke_width_re.search(style)
         if m:
@@ -223,7 +223,7 @@ class Shape(object):
             attrib['fill']=self.color
         else:
             attrib['fill']='none'
-        if self.opacity != 1.0:
+        if self.opacity != 1.0  or  "opacity" in attrib:
             attrib['opacity'] = str(self.opacity)
         attrib['stroke']=self.color
         attrib['style']="stroke-width:%d" % self.linewidth


### PR DESCRIPTION
Bug : change the opacity of a shape from 1.0 to 0.5 , it works. Change it from 0.5 to 0.8, it works. Change it back to 1.0, it does not work -- because the current code _never_ writes the attribute with value 1.0.

The rationale is probably that 1.0 is the default value anyway, but you can't rely on the default value if the attribute is present. An alternative would be simply remove the attribute when value is 1.0.
