### PR TITLE
from gi.repository import Gdk in htmleditor.py

### DIFF
--- a/lib/advene/gui/edit/htmleditor.py
+++ b/lib/advene/gui/edit/htmleditor.py
@@ -30,9 +30,11 @@ logger = logging.getLogger(__name__)
 # - Handle list item insertion
 
 from gi.repository import GObject
+from gi.repository import Gdk
 from gi.repository import Gtk
 from gi.repository import GdkPixbuf
 from gi.repository import Pango
+
 import sys
 import urllib.request, urllib.error, urllib.parse
 import socket


### PR DESCRIPTION
flake8 testing of https://github.com/oaubert/advene on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lib/advene/gui/edit/htmleditor.py:937:9: F821 undefined name 'Gdk'
        Gdk.KEY_b: lambda: t.apply_html_tag('b'),
        ^
./lib/advene/gui/edit/htmleditor.py:938:9: F821 undefined name 'Gdk'
        Gdk.KEY_i: lambda: t.apply_html_tag('i'),
        ^
./lib/advene/gui/edit/htmleditor.py:939:9: F821 undefined name 'Gdk'
        Gdk.KEY_z: lambda: t.dump_html(),
        ^
./lib/advene/gui/edit/htmleditor.py:946:32: F821 undefined name 'Gdk'
        if event.get_state() & Gdk.ModifierType.CONTROL_MASK and event.keyval in actions:
                               ^
```