### PR TITLE
Define long in Python 3

### DIFF
--- a/scripts/package_sorter.py
+++ b/scripts/package_sorter.py
@@ -26,6 +26,11 @@ from xml.etree.ElementTree import parse, Element, ElementTree, QName
 import string
 import operator
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
+
 def tag(name):
     """Return the namespaced tag.
     """


### PR DESCRIPTION
__long()__ was removed in Python 3 because all __int__ are of infinite precision.