### PR TITLE
More robust handling of Windows filenames

### DIFF
--- a/lib/advene/util/tools.py
+++ b/lib/advene/util/tools.py
@@ -459,6 +459,8 @@ def uri2path(uri):
         return uri
     if sys.platform == 'win32':
         uri = uri.replace('\\', '/')
+        if re.search('^[A-Za-z]:', uri):
+            uri = 'file:///' + uri
     u = urlparse(uri)
     if (u.scheme == 'file' and u.netloc == ""
         or u.scheme == ''):


### PR DESCRIPTION
Without this change, I could load and save again existing packages, but I could not save a newly created package.

The problem comes from the fact that the URI received by uri2path in that case was a plain Windows path (E:\foo\bar.azp) while, after opening an existing file, it is a proper file: URI.

With this change, plain Windows paths are detected and changed into file URIs.